### PR TITLE
added selector to match attribute substring for folders with query string

### DIFF
--- a/css/fancyindex.css
+++ b/css/fancyindex.css
@@ -198,7 +198,7 @@ a:hover {
           content: "";
   }
 
-  #list a[href$="/"]:before {
+  #list a[href$="/"]:before, #list a[href*="/?"]:before {
           background: url('../icons/folder_black.png') left center no-repeat;
   }
 


### PR DESCRIPTION
NgxFancyIndex v0.3.3 allows sorting columns in both ascending and descending order.  This additional selector matches directories when a query string is appended to the URL.  Without it, directories are identified as generic files, because the href value doesn't end with a forward slash.
