### PR TITLE
Decode URI when creating bread crumbs, to be friendly to Chinese.

### DIFF
--- a/css/iconfont.css
+++ b/css/iconfont.css
@@ -1,0 +1,12 @@
+.icon {
+	width: 1.2em;
+	height: 1.2em;
+	vertical-align: -0.15em;
+	fill: currentColor;
+	overflow: hidden;
+	float: left;
+	margin-right: 5px;
+}
+tr{
+	line-height: 1.5em;
+}

--- a/footer.html
+++ b/footer.html
@@ -9,7 +9,7 @@
   for (var i=0; i<segments.length; i++) {
     if (segments[i] !== '') {
       currentPath += segments[i] + '/';
-      breadcrumbs += '<a href="' +  currentPath + '">' + window.unescape(segments[i]) + '<\/a>';
+      breadcrumbs += '<a href="' +  currentPath + '">' + window.unescape(decodeURI(segments[i])) + '<\/a>';
     } else if (segments.length -1 !== i) {
       currentPath += '';
       breadcrumbs += '<a href="' + currentPath + '">Root<\/a>';

--- a/header.html
+++ b/header.html
@@ -7,7 +7,7 @@
   <title>Files...</title>
   <link rel="stylesheet" href="/fancyindex/css/fancyindex.css">
   <script>
-    window.document.title = window.location.pathname;
+    window.document.title = decodeURI(window.location.pathname);
   </script>
 </head>
 <body>

--- a/js/history.js
+++ b/js/history.js
@@ -27,7 +27,7 @@ if (!!(window.history && history.pushState)) {
   })();
 
   var updateCrumbs = function() {
-    window.document.title = window.location.pathname;
+    window.document.title = decodeURI(window.location.pathname);
     setTimeout(function () {
       var loc = window.location.pathname;
       var segments = loc.split('/');
@@ -78,7 +78,7 @@ if (!!(window.history && history.pushState)) {
       if (event.target.nodeName == 'A' && event.target.innerHTML.indexOf('/') !== -1) {
         event.preventDefault();
         swapPage(event.target.href);
-        var title = event.target.innerHTML;
+        var title = decodeURI(event.target.innerHTML);
         history.pushState({page: title}, title, event.target.href);
         updateCrumbs();
       }

--- a/js/icon.js
+++ b/js/icon.js
@@ -1,0 +1,53 @@
+var updateIcons = function(){
+	var trs = document.getElementsByTagName('tr');
+	var iconHTML = '<svg class="icon" aria-hidden="true"><use xlink:href=""></use></svg>';
+	$('tr').each(function(idx, val){
+	    var td = $(this).children('td');
+	    if(td.length >= 1){
+		td = td.eq(0);
+	        let a = td.children('a').eq(0);
+        	let filename = a.attr('href').split('?')[0];
+        	let ext = '';
+        	if (/\/$/.test(filename)) {
+        	    ext = 'icon-folder'
+        	} else if (/\.(zip|7z|bz2|gz|tar|tgz|tbz2|cab|rar)$/.test(filename)) {
+        	    ext = 'icon-file-zip'
+        	} else if (/\.(jpg|png|bmp|gif|ico|webp)$/.test(filename)) {
+        	    ext = 'icon-file-image'
+        	} else if (/\.(flv|mp4|mkv|avi|mkv|rmvb|wmv)$/.test(filename)) {
+        	    ext = 'icon-file-video'
+        	} else if (/\.(doc|docx|)$/.test(filename)) {
+        	    ext = 'icon-file-doc'
+        	} else if (/\.(torrent)$/.test(filename)) {
+        	    ext = 'icon-file-bt'
+        	} else if (/\.(txt|md)$/.test(filename)) {
+        	    ext = 'icon-file-txt'
+        	} else if (/\.(mp3|wma|wav|ogg|ape|acc|m4a)$/.test(filename)) {
+        	    ext = 'icon-file-music'
+        	} else if (/\.(srt|ass|ssa)$/.test(filename)) {
+        	    ext = 'icon-file-subtitles'
+        	} else if (/\.(py|json|xml|js|php|h|aria2)$/.test(filename)) {
+        	    ext = 'icon-file-code'
+        	} else if (/\.(nfo)$/.test(filename)) {
+        	    ext = 'icon-file-info'
+        	} else if (/\.(pdf)$/.test(filename)) {
+		    ext = 'icon-file-pdf'
+        	} else if (/\.(ppt|pptx)$/.test(filename)) {
+		   ext = 'icon-file-ppt' 
+        	} else if (/\.(xls|xlsx)$/.test(filename)) {
+		   ext = 'icon-file-excel'
+        	} else if (/\.(part)$/.test(filename)) {
+		   ext = 'icon-file-bin'
+        	} else {
+        	    ext = 'icon-file-unknown'
+       		}
+
+        	$svg = $(iconHTML);
+        	$svg.children('use').attr('xlink:href', '#'+ext);
+        	td.prepend($svg);
+    	}
+	})
+}
+$(document).ready(function(){
+	updateIcons();
+});


### PR DESCRIPTION
When I am using the newest version fancyindex in a Chinese context, there're garbled text in the bread crumbs, added decodeURI() to solve this problem.
Also, decoded URI to be shown on the browser tab.